### PR TITLE
Replace http:// with // in heartbeart web client

### DIFF
--- a/client/web/hb_client_options.html
+++ b/client/web/hb_client_options.html
@@ -9,11 +9,11 @@
 
 <a href="hb_client.html"><h3>Default <tt>hb_client.html</tt> (WITHOUT parameters!)</h3></a>
 
-<a href="hb_client.html?HB_URL=http://localhost:8888&APP_ID=browser_app"><h3><tt>hb_client.html?HB_URL=http://localhost:8888&APP_ID=browser_app_0000</tt></h3></a>
+<a href="hb_client.html?HB_URL=//localhost:8888&APP_ID=browser_app"><h3><tt>hb_client.html?HB_URL=//localhost:8888&APP_ID=browser_app_0000</tt></h3></a>
 
 <div>
     <form name="my_form">
-        HB_URL: <input type="text" name="hb_url" id="hb_url" value="????" readonly/> (to be set via <a href="hb_client.html?HB_URL=http://localhost:8888"><tt>hb_client.html?HB_URL=http://localhost:8888</tt></a>). <br/>
+        HB_URL: <input type="text" name="hb_url" id="hb_url" value="????" readonly/> (to be set via <a href="hb_client.html?HB_URL=//localhost:8888"><tt>hb_client.html?HB_URL=//localhost:8888</tt></a>). <br/>
         APP_ID: <input type="text" name="app_id" id="app_id" value="????" readonly/> (to be set via <a href="hb_client.html?APP_ID=browser_app_1111"><tt>hb_client.html?APP_ID=browser_app_1111</tt></a>). <br/>
         Interval: <input type="text" name="interval" value="2"/> seconds
     </form>
@@ -39,7 +39,7 @@ function getURLParameter(name) {
 // Shortcuts: // var hb_url = document.getElementById( "hb_url" );var app_name = document.getElementById( "app_id" ); 
 
 // parameters with hard-coded defaults:
-var HB_URL = getURLParameter('HB_URL' ) || "http://localhost:8888";
+var HB_URL = getURLParameter('HB_URL' ) || "//localhost:8888";
 var APP_ID = getURLParameter('APP_ID' ) || "browser_app_0000";
 
 // Just for show:

--- a/client/web/hilbert-heartbeat.js
+++ b/client/web/hilbert-heartbeat.js
@@ -50,7 +50,7 @@
         return xhttp;
     }
 
-    var _defaultUrl = 'http://localhost:8888';
+    var _defaultUrl = '//localhost:8888';
     var _defaultAppId = 'browser_app';
 
     /**
@@ -100,7 +100,7 @@
      * @example
      * // Full initialization.
      * var heartbeat = new Heartbeat({
-     *     url: Heartbeat.getPassedUrl('http://localhost:8881'),
+     *     url: Heartbeat.getPassedUrl('//localhost:8881'),
      *     appId: Heartbeat.getPassedAppId('test_app'),
      *     interval: 5000,
      *     sendInitCommand: true,

--- a/client/web/test_heartbeatjs.html
+++ b/client/web/test_heartbeatjs.html
@@ -11,7 +11,7 @@
     <script>
         document.write('<h1>HB messages should follow : </h1><br><hr>');
         var heartbeat = new Heartbeat({
-            url: Heartbeat.getPassedUrl('http://localhost:8888'),
+            url: Heartbeat.getPassedUrl('//localhost:8888'),
             appId: Heartbeat.getPassedAppId('mywebapp'),
             interval: 7000,
             sendInitCommand: false,


### PR DESCRIPTION
This ensures that the connection to the heartbeat server uses the same protocol used to load the web page the heartbeat script is part of (see #7). If the original protocol was something like `file://`, the heartbeat will just fail (because it also tries to connect via `file://`) and in this case the heartbeat url must be set during the initilization of the library.