### PR TITLE
Feature/send beacon

### DIFF
--- a/client/web/API.md
+++ b/client/web/API.md
@@ -16,6 +16,7 @@ This class provides functionality to send regular heartbeat
     * _instance_
         * [.send(command, interval, callback)](#Heartbeat+send) ⇒ <code>XMLHttpRequest</code>
         * [.sendSync(command, interval)](#Heartbeat+sendSync) ⇒ <code>String</code>
+        * [.sendBeacon(command, interval)](#Heartbeat+sendBeacon) ⇒ <code>Boolean</code>
         * [.sendInit()](#Heartbeat+sendInit)
         * [.sendPing()](#Heartbeat+sendPing)
         * [.sendDone()](#Heartbeat+sendDone)
@@ -83,7 +84,7 @@ var heartbeat = new Heartbeat({
 
 ### heartbeat.send(command, interval, callback) ⇒ <code>XMLHttpRequest</code>
 Generic method for sending heartbeat commands to a heartbeat server.
-The request will be send asynchronous, i.e. the method will return
+A HTTP GET request will be send asynchronously, i.e. the method will return
 almost immediately, but the callback will be called a some point in
 the future.
 
@@ -100,7 +101,7 @@ the future.
 
 ### heartbeat.sendSync(command, interval) ⇒ <code>String</code>
 Generic method for sending heartbeat commands to a heartbeat server.
-The request will be send synchronous, i.e. the method will block
+A HTTP GET request will be send synchronously, i.e. the method will block
 until the request is finished.
 
 **Kind**: instance method of [<code>Heartbeat</code>](#Heartbeat)  
@@ -109,6 +110,24 @@ until the request is finished.
 
 - <code>Error</code> - In case the request didn't succeed.
 
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| command | <code>String</code> | The heartbeat command to be send. |
+| interval | <code>Number</code> | The interval in ms the heartbeat server has                            to expect between this and the next heartbeat                            command. |
+
+<a name="Heartbeat+sendBeacon"></a>
+
+### heartbeat.sendBeacon(command, interval) ⇒ <code>Boolean</code>
+Generic method for sending heartbeat commands to a heartbeat server.
+A HTTP POST request will be send asynchronously, but the method will wait
+until the request has been successfully queued or an error occured.
+
+**Kind**: instance method of [<code>Heartbeat</code>](#Heartbeat)  
+**Returns**: <code>Boolean</code> - - True if the request has been queued successfully,
+                     false otherwise. False will also be returned if this
+                     is not supported.  
 **Access**: public  
 
 | Param | Type | Description |
@@ -133,9 +152,11 @@ without error handling or feedback.
 <a name="Heartbeat+sendDone"></a>
 
 ### heartbeat.sendDone()
-Sends the done command synchronously using default appId, 0ms interval
-and without error handling or feedback. No further heartbeats will be
-send after this command unless setInterval() is called again.
+Sends the done using default appId, 0ms interval and without error
+handling or feedback. It will internally use the [sendBeacon](#Heartbeat+sendBeacon)
+method and fall back to [sendSync](#Heartbeat+sendSync) in case of an error. No further
+heartbeats will be send after this command unless setInterval() is called
+again.
 
 **Kind**: instance method of [<code>Heartbeat</code>](#Heartbeat)  
 <a name="Heartbeat+getInterval"></a>

--- a/client/web/README.md
+++ b/client/web/README.md
@@ -88,7 +88,7 @@ heartbeat.sendDone();
 Note that you still should not wait longer then `heartbeat.getInterval()` milliseconds until sending the next heartbeat.
 
 ### Full control over the heartbeat command
-The `send()` and `sendSync()` methods give you full control over the heartbeat requests sent.
+The `send()`, `sendSync()` and `sendBeacon()` methods give you full control over the heartbeat requests sent.
 
 #### Asynchronous operation
 Usually, heartbeats should be sent asynchronously:
@@ -103,13 +103,15 @@ var xhttp = heartbeat.send(Heartbeat.getPingCommand(),2000,cp);
 ```
 In this example, `xhttp` is a `XMLHttpRequest` object whose `send()` method has already been called. It can be useful if you need to abort a certain request. You should send the next heartbeat within the next two seconds after the current one.
 
+If you are not interested in the response of the heartbeat server, you should use `sendBeacon()` instead. It will only work with recent browser versions (because it relies on `navigator.sendBeacon()`), but if it is available, it will also work on an `unload` event, e.g. for sending the `hb_done` command (which might not be delivered on `unload` when `send()` or `sendSync()` are used).
+
 #### Synchronous operation
-Sometimes, doing a blocking call can be useful, e.g. if you want to the send the `hb_done` command (because if you send it asynchronous and directly exit your program afterwards, the request might get lost):
+Sometimes, doing a blocking call can be useful:
 ```
 heartbeat.abort();
 var response = heartbeat.sendSync(Heartbeat.getDoneCommand(),0);
 ```
-The `abort()` command beforehand makes sure that no other asynchronous requests are in the pipeline before the `hb_done` command is send out. Otherwise, the heartbeat server might receive them out of order.
+The `abort()` command beforehand makes sure that no other asynchronous requests are in the pipeline before the `hb_done` command is send out. Otherwise, the heartbeat server might receive them out of order. Note that using `sendSync()` on an `unload` event might not work as expected. Use `sendBeacon()` instead.
 
 ## Generating the API documentation
 

--- a/server/heartbeat3.py
+++ b/server/heartbeat3.py
@@ -165,6 +165,8 @@ class MyHandler(BaseHTTPRequestHandler):
             # WHAT ELSE????
         return
 
+    def do_POST(s):
+        MyHandler.do_GET(s)
 
 def test_server(HandlerClass=MyHandler, ServerClass=HTTPServer, protocol="HTTP/1.0"):
     """Test the HTTP request handler class.


### PR DESCRIPTION
`sendDone()` should now work reliably on `window.unload` (at least on modern browsers).